### PR TITLE
t3501: Use test_path_is_* Functions

### DIFF
--- a/t/t3501-revert-cherry-pick.sh
+++ b/t/t3501-revert-cherry-pick.sh
@@ -67,7 +67,7 @@ test_expect_success 'cherry-pick after renaming branch' '
 	git checkout rename2 &&
 	git cherry-pick added &&
 	test $(git rev-parse HEAD^) = $(git rev-parse rename2) &&
-	test -f opos &&
+	test_path_is_file opos &&
 	grep "Add extra line at the end" opos &&
 	git reflog -1 | grep cherry-pick
 
@@ -78,7 +78,7 @@ test_expect_success 'revert after renaming branch' '
 	git checkout rename1 &&
 	git revert added &&
 	test $(git rev-parse HEAD^) = $(git rev-parse rename1) &&
-	test -f spoo &&
+	test_path_is_file spoo &&
 	! grep "Add extra line at the end" spoo &&
 	git reflog -1 | grep revert
 


### PR DESCRIPTION
Two test -f are present in t3501. They can be replaced with appropriate helper function test_path_is_file

Signed-off-by: Labnann <khalid.masum.92@gmail.com>


